### PR TITLE
Format for timestamps

### DIFF
--- a/lib/action_presenter/defaults/timestamps.rb
+++ b/lib/action_presenter/defaults/timestamps.rb
@@ -1,18 +1,18 @@
 module ActionPresenter
   module Defaults
     module Timestamps
-      def created_at
-        localize_time :created_at
+      def created_at(format = :default)
+        localize_time :created_at, format
       end
 
-      def updated_at
-        localize_time :updated_at
+      def updated_at(format = :default)
+        localize_time :updated_at, format
       end
 
     private
 
-      def localize_time(time)
-        I18n.l(object.try(time)) if object.respond_to?(time)
+      def localize_time(time, format)
+        I18n.l(object.try(time), format: format) if object.respond_to?(time)
       end
     end
   end

--- a/spec/action_presenter/defaults/timestamps_spec.rb
+++ b/spec/action_presenter/defaults/timestamps_spec.rb
@@ -43,4 +43,17 @@ describe ActionPresenter::Defaults::Timestamps do
       end.should == time
     end
   end
+
+  context "#format" do
+    it 'should return short localized date' do
+      I18n.should_receive(:l).with(time_now, {format: :short}).and_return time
+      klass.created_at(:short).should == time
+    end
+
+    it 'should return long localized date' do
+      I18n.should_receive(:l).with(time_now, {format: :long}).and_return time
+      klass.created_at(:long).should == time
+    end
+
+  end
 end

--- a/spec/action_presenter/defaults/timestamps_spec.rb
+++ b/spec/action_presenter/defaults/timestamps_spec.rb
@@ -5,41 +5,42 @@ require 'support/dummy_action_controller'
 describe ActionPresenter::Defaults::Timestamps do
   include ActionControllerHelper
 
-  let(:time) { Time.now }
+  let(:time_now) { Time.now }
+  let(:time) { 'Fri, 17 Feb 2012 01:46:08 +0100' }
 
-  let(:object) { mock(Object, created_at: time, updated_at: time) }
+  let(:object) { mock(Object, created_at: time_now, updated_at: time_now) }
   let(:template) { mock(Object) }
 
   let(:klass) { DummyPresenter.new(object, template) }
 
   it 'should return localized #created_at' do
-    I18n.should_receive(:l).and_return("Fri, 17 Feb 2012 01:46:08 +0100")
-    klass.created_at.should == "Fri, 17 Feb 2012 01:46:08 +0100"
+    I18n.should_receive(:l).and_return time
+    klass.created_at.should == time
   end
 
   it 'should return localized #updated_at' do
-    I18n.should_receive(:l).and_return("Fri, 17 Feb 2012 01:46:08 +0100")
-    klass.updated_at.should == "Fri, 17 Feb 2012 01:46:08 +0100"
+    I18n.should_receive(:l).and_return time
+    klass.updated_at.should == time
   end
 
   context 'in view context' do
     let(:object) { 'foobar' }
-    before { I18n.should_receive(:l).and_return 'Fri, 17 Feb 2012 01:46:08 +0100' }
+    before { I18n.should_receive(:l).and_return time }
 
     it 'should return #created_at' do
-      object.should_receive(:created_at).and_return '2012-02-17 01:46:08 +0100'
+      object.should_receive(:created_at).and_return time
 
       helper.present(object) do |p|
         p.created_at
-      end.should == 'Fri, 17 Feb 2012 01:46:08 +0100'
+      end.should == time
     end
 
     it 'should return #updated_at' do
-      object.should_receive(:updated_at).and_return '2012-02-17 01:46:08 +0100'
+      object.should_receive(:updated_at).and_return time
 
       helper.present(object) do |p|
         p.updated_at
-      end.should == 'Fri, 17 Feb 2012 01:46:08 +0100'
+      end.should == time
     end
   end
 end


### PR DESCRIPTION
It's possible now to change timestamps format

``` haml
- present @article do |p|
  = p.created_at :short
  = p.created_at :long

  = p.updated_at :short
  = p.updated_at :long
```
