### PR TITLE
Fix present helper

### DIFF
--- a/lib/action_presenter/view_helper.rb
+++ b/lib/action_presenter/view_helper.rb
@@ -7,7 +7,10 @@ module ActionPresenter
     end
 
     def present(object, klass = "#{object.class}Presenter".constantize)
-      yield klass.new(object, view_context) if block_given?
+      presenter = klass.new(object, view_context)
+
+      return yield presenter if block_given?
+      presenter
     end
   end
 end

--- a/spec/action_presenter/view_helper_spec.rb
+++ b/spec/action_presenter/view_helper_spec.rb
@@ -8,14 +8,14 @@ describe ActionPresenter::ViewHelper do
 
   it 'should call default presenter if presenter class is not given' do
     helper.present('foobar') do |p|
-      p.foobar
-    end.should == 'foo'
+      p.should be_instance_of StringPresenter
+    end
   end
 
   it 'should call given presenter class' do
     helper.present('foobar', FoobarPresenter) do |p|
-      p.foobar
-    end.should == 'bar'
+      p.should be_instance_of FoobarPresenter
+    end
   end
 
   it 'should return nil if no block is given' do

--- a/spec/action_presenter/view_helper_spec.rb
+++ b/spec/action_presenter/view_helper_spec.rb
@@ -18,7 +18,7 @@ describe ActionPresenter::ViewHelper do
     end
   end
 
-  it 'should return nil if no block is given' do
-    helper.present('foobar').should be_nil
+  it 'should return presenter instance if no block is given' do
+    helper.present('foobar').should be_instance_of StringPresenter
   end
 end


### PR DESCRIPTION
Fixed #present view helper. It now returns presenter instance if block is not given. It's now possible to easly use it in controller.
### Example
#### Object (model)

``` ruby
class Foo
  def foo
    'foo'
  end

  def bar
    'bar'
  end

  def foobar
    'foobar' * 3
  end
end
```
#### Presenter

``` ruby
class FooPresenter < ActionPresenter::Base
  presents :foo

  @@user_attributes  = [:foo, :foobar]
  @@admin_attributes = [:foo, :bar, :foobar]

  def index
    attrs = current_user.admin? ? @@admin_attributes : @@user_attributes
    Hash[*attrs.map {|attr| [attr, foo.send(attr)]}.flatten]
  end
end
```
#### Controller

``` ruby
class FooController < ApplicationController
  respond_to :json, :xml

  def index
    respond_with present(Foo.new).index
  end
end
```
