### PR TITLE
Rails 5 API: undefined method `helper_method' for ActionController::API:Class (NoMethodError) Fix.

### DIFF
--- a/lib/action_presenter/view_helper.rb
+++ b/lib/action_presenter/view_helper.rb
@@ -3,7 +3,9 @@ module ActionPresenter
     extend ActiveSupport::Concern
 
     included do
-      helper_method :present, :present_collection
+      if respond_to?(:helper_method)
+        helper_method :present, :present_collection
+      end
     end
 
     def present(object, klass = nil)


### PR DESCRIPTION
Similar issue described in plataformatec/devise#3690
Identical fix to plataformatec/devise#3732